### PR TITLE
Change the Font path to avoid font not found error

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'font'=>'packages/wikichua/captcha/fonts/luxisr.ttf', 
+    'font'=> __DIR__ .'/../../public/fonts/luxisr.ttf', 
     'count'=>40,  
     'fontSize'=>20,  
     'height'=>50,  


### PR DESCRIPTION
In the normal installation of Laravel-4 there is no Packages folder unless the developer want to publish the assets and rename the folder of the public assets, then he could change the path to whatever he likes.
